### PR TITLE
Switch from a footnote to an annotation to appease lint check.

### DIFF
--- a/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
@@ -190,18 +190,22 @@ iree-compile \
     mobilenet_iree_input.mlir -o mobilenet_vulkan.vmfb
 ```
 
-!!! note
+!!! note annotate
     Currently a target triple of the form `<vendor/arch>-<product>-<os>` is needed
     to compile towards a specific GPU architecture.
 
-    We don't support the full spectrum here[^1]; the following table summarizes the
-    currently recognized ones.
+    We don't support the full spectrum here(1); the following table summarizes
+    the currently recognized ones.
 
     If no triple is specified, then a safe but more limited default will be used.
 
     This is more of a mechanism to help us develop IREE itself--in the long term
     we want to perform multiple targetting to generate to multiple architectures
     if no target triple is given.
+
+1. It's also impossible to capture all details of a Vulkan implementation
+   with a target triple, given the allowed variances on extensions, properties,
+   limits, etc. So the target triple is just an approximation for usage.
 
 | GPU Vendor          | Target Triple                                 |
 | ------------------- | --------------------------------------------- |
@@ -233,7 +237,3 @@ concrete values.
 <!-- TODO(??): measuring performance -->
 
 <!-- TODO(??): troubleshooting -->
-
-[^1]: It's also impossible to capture all details of a Vulkan implementation
-with a target triple, given the allowed variances on extensions, properties,
-limits, etc. So the target triple is just an approximation for usage.


### PR DESCRIPTION
The `MD053/link-image-reference-definitions` markdownlint rule does not look within (non-standard) admonitions.

See https://github.com/openxla/iree/pull/15734#discussion_r1410115741